### PR TITLE
BUG fixed

### DIFF
--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/CrystalMimic.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/CrystalMimic.java
@@ -29,6 +29,7 @@ import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.AllyBuff;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Buff;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Dread;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Haste;
+import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Levitation;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Terror;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Hero;
 import com.shatteredpixel.shatteredpixeldungeon.effects.CellEmitter;
@@ -54,7 +55,6 @@ public class CrystalMimic extends Mimic {
 
 	{
 		spriteClass = MimicSprite.Crystal.class;
-		flying = true;
 		FLEEING = new Fleeing();
 	}
 
@@ -107,6 +107,7 @@ public class CrystalMimic extends Mimic {
 
 	public void stopHiding(){
 		state = FLEEING;
+		Buff.affect(this, Levitation.class, Levitation.DURATION/2f);
 		//haste for 2 turns if attacking
 		if (alignment == Alignment.NEUTRAL){
 			Buff.affect(this, Haste.class, 2f);

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Mob.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Mob.java
@@ -870,7 +870,7 @@ public abstract class Mob extends Char {
 		PaswordBadges.loadGlobal();
 		List<PaswordBadges.Badge> passwordbadges = PaswordBadges.filtered( true );
 		if (global.contains( Badges.Badge.KILL_APPLE ) && global.contains( Badges.Badge.KILL_DM720 ) &&
-				global.contains( Badges.Badge.KILL_MG) && passwordbadges.contains(PaswordBadges.Badge.FIREGIRL) && passwordbadges.contains(PaswordBadges.Badge.DRAWF_HEAD) && passwordbadges.contains(PaswordBadges.Badge.SAKA_DIED)) {
+				global.contains( Badges.Badge.KILL_MG) && passwordbadges.contains(PaswordBadges.Badge.FIREGIRL) && passwordbadges.contains(PaswordBadges.Badge.DRAWF_HEAD) && passwordbadges.contains(PaswordBadges.Badge.SAKA_DIED) && !passwordbadges.contains(PaswordBadges.Badge.SPICEALBOSS)) {
 
 			PaswordBadges.Badge badge = PaswordBadges.Badge.SPICEALBOSS;
 			PaswordBadges.displayBadge( badge );

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/quest/MIME.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/quest/MIME.java
@@ -21,7 +21,6 @@
 
 package com.shatteredpixel.shatteredpixeldungeon.items.quest;
 
-import com.shatteredpixel.shatteredpixeldungeon.Statistics;
 import com.shatteredpixel.shatteredpixeldungeon.actors.hero.Hero;
 import com.shatteredpixel.shatteredpixeldungeon.items.Item;
 import com.shatteredpixel.shatteredpixeldungeon.sprites.ItemSpriteSheet;
@@ -104,7 +103,6 @@ public class MIME extends Item {
     public boolean doPickUp(Hero hero, int pos) {
         if (super.doPickUp(hero, pos)) {
             if(!isMimeSupported){
-                Statistics.dimandchestmazeCollected++;
                 isMimeSupported = true;
             }
             return true;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/ColdChestBossLevel.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/ColdChestBossLevel.java
@@ -338,6 +338,7 @@ public class ColdChestBossLevel extends Level {
                             break;
                     }
                 }
+                Statistics.dimandchestmazeCollected++;
 
                 pro = START;
                 break;
@@ -395,6 +396,7 @@ public class ColdChestBossLevel extends Level {
                                     }
                                 }
                             }
+                            Statistics.dimandchestmazeCollected++;
 
                             switch (Random.NormalIntRange(0,8)){
                                 case 0:
@@ -488,6 +490,7 @@ public class ColdChestBossLevel extends Level {
                                     }
                                 }
                             }
+                            Statistics.dimandchestmazeCollected++;
 
                             //生成四个水晶，宝箱王持续回血
                             for (int i : FourCrystal) {

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/scenes/InterlevelScene.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/scenes/InterlevelScene.java
@@ -287,6 +287,7 @@ public class InterlevelScene extends PixelScene {
 								break;
 							case ANCITYBOSS:
 								exboss(4);
+								break;
 							case GARDEN:
 								exboss(5);
 								break;


### PR DESCRIPTION
1.水晶宝箱怪现在给与10回合浮空而不是飞行能力
2.弱肉强食获得判断，现在不会刷屏了
3.修复了后续不会生成其他宝藏的BUG
4.归溯银剑传送到其他任务房间的问题